### PR TITLE
Add pytest CLI test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+tqdm
+pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_missing_u_exits_with_error():
+    script = Path(__file__).resolve().parents[1] / "s3d.py"
+    proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert proc.stderr, "Expected an error message"


### PR DESCRIPTION
## Summary
- add a basic pytest test that invokes `s3d.py` with no arguments and checks for an error
- provide requirements file listing needed dependencies for running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687642546e148321ac44349115d83635