### PR TITLE
Require URL parameter

### DIFF
--- a/s3d.py
+++ b/s3d.py
@@ -15,8 +15,10 @@ def my_progress_bar(current_value, max_value,file_name):
     tqdm.write(f"\r[{bar}] {progress:.0%} : {file_name}", end="")
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-d', action='store_true')
-parser.add_argument('-u', type=str)
+parser.add_argument('-d', action='store_true',
+                    help="Download files instead of dry run")
+parser.add_argument('-u', type=str, required=True,
+                    help="URL of the S3 bucket to process (required)")
 args = parser.parse_args()
 
 download = args.d


### PR DESCRIPTION
## Summary
- enforce the `-u` bucket URL argument as mandatory
- add help text for download flag and URL

## Testing
- `python3 s3d.py` *(fails: required argument error)*

------
https://chatgpt.com/codex/tasks/task_e_6876424d0628832184ba0dcdfd10dac4